### PR TITLE
feat: support additional api files via cli

### DIFF
--- a/bin/swagger-jsdoc-deref
+++ b/bin/swagger-jsdoc-deref
@@ -31,12 +31,6 @@ if (!program.definition) {
   process.exit(1);
 }
 
-// Support optional api files
-if (program.args.length) {
-  sourceApis = source.apis || [];
-  source.apis = sourceApis.concat(program.args);
-}
-
 // Override default output file if provided.
 if (program.output) {
   // eslint-disable-next-line prefer-destructuring
@@ -44,5 +38,11 @@ if (program.output) {
 }
 
 const source = require(path.join(process.cwd(), program.definition));
+
+// Support optional api files
+if (program.args.length) {
+  const sourceApis = source.apis || [];
+  source.apis = sourceApis.concat(program.args);
+}
 
 require('..')({ source, output });

--- a/bin/swagger-jsdoc-deref
+++ b/bin/swagger-jsdoc-deref
@@ -31,6 +31,12 @@ if (!program.definition) {
   process.exit(1);
 }
 
+// Support optional api files
+if (program.args.length) {
+  sourceApis = source.apis || [];
+  source.apis = sourceApis.concat(program.args);
+}
+
 // Override default output file if provided.
 if (program.output) {
   // eslint-disable-next-line prefer-destructuring

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const writeFile = promisify(fs.writeFile);
 module.exports = async function swaggerJsDocDeref({ source, output }) {
   const options = { ...source, swaggerDefinition: source };
   delete options.swaggerDefinition.apis;
+  
   const rawSpec = swaggerDoc(options);
   const spec = await jsonRefs.resolveRefs(rawSpec);
   return writeFile(output, JSON.stringify(spec.resolved, null, 2));

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const writeFile = promisify(fs.writeFile);
 module.exports = async function swaggerJsDocDeref({ source, output }) {
   const options = { ...source, swaggerDefinition: source };
   delete options.swaggerDefinition.apis;
-  
+
   const rawSpec = swaggerDoc(options);
   const spec = await jsonRefs.resolveRefs(rawSpec);
   return writeFile(output, JSON.stringify(spec.resolved, null, 2));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A CLI that uses swagger-jsdoc to generate Swagger definitions, but dereferences all json-refs for compatibility.",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint-godaddy *.js \"{bin,test}/**/*.js\"",
+    "lint": "eslint-godaddy --ignore-pattern \"**/*.yaml\" *.js \"{bin,test}/**/*\"",
     "test": "nyc --reporter=text --reporter=json-summary npm run test:mocha",
     "test:mocha": "mocha \"test/**/*.test.js\"",
     "posttest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A CLI that uses swagger-jsdoc to generate Swagger definitions, but dereferences all json-refs for compatibility.",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint-godaddy *.js \"{bin,test}/**/*\"",
+    "lint": "eslint-godaddy *.js \"{bin,test}/**/*.js\"",
     "test": "nyc --reporter=text --reporter=json-summary npm run test:mocha",
     "test:mocha": "mocha \"test/**/*.test.js\"",
     "posttest": "npm run lint",

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -13,13 +13,15 @@ const exec = promisify(childProcess.exec);
 describe('e2e', function () {
   const outputFile = 'test/fixtures/output.json';
   const inputFile = 'test/fixtures/swagger.js';
+  const additionalFile = 'test/fixtures/additional-api.yaml';
   const outputPath = path.join(__dirname, 'fixtures', 'output.json');
-  const baseCommand = `${process.env.PWD}/bin/swagger-jsdoc-deref -o ${outputFile} -d ${inputFile}`;
+  const baseCommand = `${process.env.PWD}/bin/swagger-jsdoc-deref -o ${outputFile} ${additionalFile} -d ${inputFile}`;
 
   afterEach(async function () {
     await unlink(outputPath);
   });
 
+  /* eslint-disable max-statements */
   it('generates output', async function () {
     await exec(baseCommand, { cwd: process.env.PWD });
 
@@ -27,12 +29,19 @@ describe('e2e', function () {
 
     const rawFile = await readFile(outputPath, 'utf8');
     assume(rawFile).to.exist();
+
     const data = JSON.parse(rawFile);
     assume(data).to.exist();
     assume(data.paths).to.exist();
+
     const route = data.paths['/foo/{bar}'];
     assume(route).to.exist();
     assume(route.get).to.exist();
+
+    // Make sure additional apis are added
+    const additionalRoute = data.paths['/additional'];
+    assume(additionalRoute).to.exist();
+    assume(additionalRoute.get).to.exist();
 
     // Make sure parameters are dereferenced
     assume(route.get.parameters).to.have.length(1);

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -15,7 +15,7 @@ describe('e2e', function () {
   const inputFile = 'test/fixtures/swagger.js';
   const additionalFile = 'test/fixtures/additional-api.yaml';
   const outputPath = path.join(__dirname, 'fixtures', 'output.json');
-  const baseCommand = `${process.env.PWD}/bin/swagger-jsdoc-deref -o ${outputFile} ${additionalFile} -d ${inputFile}`;
+  const baseCommand = `${process.env.PWD}/bin/swagger-jsdoc-deref -o ${outputFile} -d ${inputFile}`;
 
   afterEach(async function () {
     await unlink(outputPath);
@@ -38,11 +38,6 @@ describe('e2e', function () {
     assume(route).to.exist();
     assume(route.get).to.exist();
 
-    // Make sure additional apis are added
-    const additionalRoute = data.paths['/additional'];
-    assume(additionalRoute).to.exist();
-    assume(additionalRoute.get).to.exist();
-
     // Make sure parameters are dereferenced
     assume(route.get.parameters).to.have.length(1);
     assume(route.get.parameters[0].description).to.equal('Type of bar');
@@ -51,5 +46,22 @@ describe('e2e', function () {
     assume(route.get.responses).to.exist();
     assume(route.get.responses['200']).to.exist();
     assume(route.get.responses['200'].description).to.equal('Here\'s the thing you wanted');
+  });
+
+  it('generates output w/ additional apis', async function () {
+    const baseCommandWithApis = `${baseCommand} ${additionalFile}`;
+    await exec(baseCommandWithApis, { cwd: process.env.PWD });
+
+    assume(await exists(outputPath)).to.be.true();
+
+    const rawFile = await readFile(outputPath, 'utf8');
+    assume(rawFile).to.exist();
+
+    const data = JSON.parse(rawFile);
+
+    // Make sure additional apis are added
+    const additionalRoute = data.paths['/additional'];
+    assume(additionalRoute).to.exist();
+    assume(additionalRoute.get).to.exist();
   });
 });

--- a/test/fixtures/additional-api.yaml
+++ b/test/fixtures/additional-api.yaml
@@ -1,0 +1,22 @@
+openapi: '3.0.0'
+info:
+  title: Some additional API
+  version: '1.0.0'
+servers:
+  - url: additional.api.url
+paths:
+  /additional:
+    get:
+      description: Standard Page
+      responses:
+        '200':
+          $ref: '#/responses/Standard200'
+
+components:
+  responses:
+    Standard200:
+      description: OK
+      content:
+        text/html:
+          schema:
+            type: string

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -27,7 +27,13 @@ describe('swagger-jsdoc-deref', function () {
   });
 
   it('calls swagger-jsdoc', async function () {
-    const source = { some: 'file' };
+    const source = {
+      some: 'file',
+      apis: [
+        'apifile1',
+        'apifile2'
+      ]
+    };
     const output = '/tmp/foo/bar.json';
     const rawSwagger = { another: 'thing' };
     const swaggerDoc = { finally: 'done' };


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary
[swagger-jsdoc](https://github.com/Surnet/swagger-jsdoc) supports [providing additional APIs/Snippets](https://github.com/Surnet/swagger-jsdoc#goals) via the CLI.  Since this tool is simply a wrapper for running `swagger-jsdoc` and feeding the result to `json-refs` then we should support the expected behaviour of `swagger-jsdoc` closely. 

## Changelog

Add remaining CLI `args` to the source Swagger Definition's existing `apis` array. 

## Test Plan

A `yaml` test fixture was provided and consumed by the E2E test. I then confirmed the `additional` path was added to the final end result. 